### PR TITLE
Remove pnpm version from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
       
       - name: 🔨 Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: 🧨 Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
Removes PNPM version from _Setup pnpm_ step of the release workflow to prevent version mismatch errors. Since our `package.json` includes `packageManager` the `version` input is not necessary ([see docs](https://github.com/pnpm/action-setup/tree/v4/?tab=readme-ov-file#version)).