### PR TITLE
Expose `disableTypeChecked` config from tseslint

### DIFF
--- a/.changeset/shiny-grapes-add.md
+++ b/.changeset/shiny-grapes-add.md
@@ -1,0 +1,5 @@
+---
+"@bengsfort/eslint-config-flat": patch
+---
+
+Removed Astro prettier plugin from prettier config

--- a/.changeset/spicy-islands-kick.md
+++ b/.changeset/spicy-islands-kick.md
@@ -1,0 +1,5 @@
+---
+"@bengsfort/eslint-config-flat": patch
+---
+
+Expose tseslint disableTypeChecked config

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,8 +1,9 @@
 import type { Linter } from 'eslint';
 
 declare const configs: {
-    strict: Linter.Config,
+    strict: Linter.Config;
     strictTypeChecked: (tsconfigRoot: string) => Linter.Config;
+    disableTypeChecked: Linter.Config;
 };
 
 declare const _default: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,11 @@
+import tseslint from 'typescript-eslint';
 import strictConfig from './configs/strict.js';
 import strictTypeCheckedConfig from './configs/strictTypeChecked.js';
 
 const configs = {
   strict: strictConfig,
   strictTypeChecked: strictTypeCheckedConfig,
+  disableTypeChecked: tseslint.configs.disableTypeChecked,
 };
 
 export default {

--- a/lib/prettier.config.js
+++ b/lib/prettier.config.js
@@ -9,15 +9,6 @@ const config = {
   overrides: [],
   printWidth: 90,
   singleAttributePerLine: false,
-  plugins: ['prettier-plugin-astro'],
-  overrides: [
-    {
-      files: '*.astro',
-      options: {
-        parser: 'astro',
-      },
-    },
-  ],
 };
 
 export default config;


### PR DESCRIPTION
- Exposes `disableTypeChecked` config from tseslint so it can be easily disabled without adding `typescript-eslint` as an explicit dependency downstream.
- Removes unwanted Astro plugin from prettier config.