### PR TITLE
Enable creating github releases on successful publishes

### DIFF
--- a/.changeset/loose-tigers-dress.md
+++ b/.changeset/loose-tigers-dress.md
@@ -1,0 +1,5 @@
+---
+"@bengsfort/eslint-config-flat": patch
+---
+
+[internal] Enable creating github releases on successful publishes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           commit: "chore: Update package version"
           title: "chore: Update package version"
           publish: pnpm ci:publish
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Adds `createGithubReleases` input to `changesets/action@v1`