### PR TITLE
Disable unresolved  imports rule

### DIFF
--- a/.changeset/warm-planes-report.md
+++ b/.changeset/warm-planes-report.md
@@ -1,0 +1,5 @@
+---
+"@bengsfort/eslint-config-flat": patch
+---
+
+Disable 'import/no-unresolved' due to excessive false-positives

--- a/lib/base/base.js
+++ b/lib/base/base.js
@@ -23,16 +23,6 @@ export default [
       'no-unused-vars': 'off', // Disabled as it is handled by typescript-eslint
       'no-underscore-dangle': 'off',
       'class-methods-use-this': 'off', // Not a fan of forcing all methods to static.
-      // 'sort-imports': [
-      //   'error',
-      //   {
-      //     ignoreCase: false,
-      //     ignoreDeclarationSort: true,
-      //     ignoreMemberSort: false,
-      //     memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single'],
-      //     allowSeparatedGroups: true,
-      //   },
-      // ],
       '@stylistic/padding-line-between-statements': [
         'error',
         { blankLine: 'always', prev: 'block-like', next: 'block-like' },
@@ -77,6 +67,9 @@ export default [
       'import/namespace': 'off',
       'import/no-absolute-path': 'error',
       'import/no-cycle': 'off',
+      // @todo: This is currently throwing a LOT of false-positives, and the
+      // docs are still quite poor with regards to flat configs. Off for now.
+      'import/no-unresolved': 'off',
     },
   },
   pluginPrettier,


### PR DESCRIPTION
Disables `import/no-unresolved` due to an excessive number of false-positives. The [docs](https://github.com/import-js/eslint-plugin-import/tree/main?tab=readme-ov-file#config---flat-eslintconfigjs) are still quite poor with regards to flat configs, so will have to revisit later.