### PR TITLE
Expose tseslint.config helper

### DIFF
--- a/.changeset/swift-pillows-show.md
+++ b/.changeset/swift-pillows-show.md
@@ -1,0 +1,5 @@
+---
+"@bengsfort/eslint-config-flat": patch
+---
+
+Expose the ts-eslint config helper function for easier composability.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,5 @@
 import type { Linter } from 'eslint';
+import type { ConfigArray, InfiniteDepthConfigWithExtends } from 'typescript-eslint';
 
 declare const configs: {
     strict: Linter.Config;
@@ -8,6 +9,7 @@ declare const configs: {
 
 declare const _default: {
     configs: typeof configs;
+    defineConfig: (...configs: InfiniteDepthConfigWithExtends[]) => ConfigArray;
 };
 
 export default _default;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,4 +10,5 @@ const configs = {
 
 export default {
   configs,
+  defineConfig: tseslint.config,
 };


### PR DESCRIPTION
Exposes the tseslint config helper for better composability and extension, without requiring downstream projects to manually import typescript-eslint.